### PR TITLE
Fix "Cannot read property 'kind' of undefined" error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-tags",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-tags",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Use custom tags to slice up Cypress test runs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ const transformer = (config: Cypress.PluginConfigOptions) => <T extends ts.Node>
       const firstArg = node.arguments[0];
       const secondArg = node.arguments[1];
 
-      const firstArgIsTag = ts.isStringLiteral(firstArg) && ts.isStringLiteral(secondArg);
+      const firstArgIsTag = firstArg && ts.isStringLiteral(firstArg) && secondArg && ts.isStringLiteral(secondArg);
 
       if (ts.isIdentifier(node.expression)) {
         if (isDescribe(node) || isContext(node)) {


### PR DESCRIPTION
Fixes the following error:

```
The following error was thrown by a plugin. We stopped running your tests because a plugin crashed. Please check your plugins file (`/Users/anna/Development/cleric/cypress/plugins/index.js`)

 TypeError: Cannot read property 'kind' of undefined
    at Object.isStringLiteral (/Users/anna/Development/cleric/node_modules/typescript/lib/typescript.js:25483:21)
    at visit (/Users/anna/Development/cleric/node_modules/cypress-tags/dist/index.js:110:56)
    at /Users/anna/Development/cleric/node_modules/cypress-tags/dist/index.js:154:84
    at visitNode (/Users/anna/Development/cleric/node_modules/typescript/lib/typescript.js:78318:23)
    at Object.visitEachChild (/Users/anna/Development/cleric/node_modules/typescript/lib/typescript.js:78678:64)
```