### PR TITLE
Upgrade Typescript to 4.3.5 and change createEmptyStatement to create…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5107,9 +5107,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "umd": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mocha": "^9.0.2",
     "ts-node": "^10.0.0",
     "tsify": "^5.0.2",
-    "typescript": "^4.2.3"
+    "typescript": "^4.3.5"
   },
   "keywords": [
     "cypress",

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,7 @@ const transformer = (config: Cypress.PluginConfigOptions) => <T extends ts.Node>
 
     if (skipNode) {
       // Replaces node with semi-colon, effectively skipping node and any children
-      returnNode = factory.createEmptyStatement();
+      returnNode = factory.createOmittedExpression();
     } else {
       returnNode = ts.visitEachChild(returnNode, (node) => visit(node, tags), context);
     }


### PR DESCRIPTION
…OmittedExpression to fix Unhandled SyntaxKind error

Using createEmptyStatement throws Unhandled SyntaxKind failure in recent Typescript version. Replace createEmptyStatement with createOmittedExpression to fix failure.